### PR TITLE
Fixed CMIS-983

### DIFF
--- a/DotCMIS/binding/atompub/atompub-parser.cs
+++ b/DotCMIS/binding/atompub/atompub-parser.cs
@@ -393,6 +393,10 @@ namespace DotCMIS.Binding.AtomPub
                             Skip(reader);
                         }
                     }
+                    else if (AtomPubConstants.NamespaceApacheChemistry == reader.NamespaceURI)
+                    {
+                        feed.AddElement(ParseLong(reader));
+                    }
                     else
                     {
                         Skip(reader);

--- a/DotCMIS/binding/atompub/atompub.cs
+++ b/DotCMIS/binding/atompub/atompub.cs
@@ -2697,6 +2697,7 @@ namespace DotCMIS.Binding.AtomPub
             // read and parse
             HttpUtils.Response resp = Read(url);
             AtomFeed feed = Parse<AtomFeed>(resp.Stream);
+            String lastChangeLogToken = null;
 
             // handle top level
             foreach (AtomElement element in feed.GetElements())
@@ -2711,6 +2712,10 @@ namespace DotCMIS.Binding.AtomPub
                 else if (IsInt(NameNumItems, element))
                 {
                     result.NumItems = (long)element.Object;
+                }
+                else if (IsStr("changeLogToken", element))
+                {
+                    lastChangeLogToken = (string)element.Object;
                 }
             }
 
@@ -2736,6 +2741,12 @@ namespace DotCMIS.Binding.AtomPub
                         result.Objects.Add(hit);
                     }
                 }
+
+            if (changeLogToken != null)
+            {
+                // the AtomPub binding cannot return a new change log token,
+                // but an OpenCMIS server uses a proprietary tag
+                changeLogToken = lastChangeLogToken;
             }
 
             return result;


### PR DESCRIPTION
AtomPub: DotCMIS IChangeEvents.LatestChangeLogToken returns same token as given to GetContentChanges
